### PR TITLE
HB-UNI-Sen-LEV-US V1.1

### DIFF
--- a/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
+++ b/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
@@ -126,8 +126,8 @@
          <parameter type="integer" index="9.0" size="1.0" param="FILLING_LEVEL" />
          <parameter type="integer" index="10.0" size="1.0" param="BATTERY_VOLTAGE"/>
          <parameter type="integer" index="11.0" size="4.0" param="FILLING_LITER"/>
-	 <parameter type="integer" index="15.0" size="2.0" param="FILLING_HEIGHT" />
-	 </frame>
+         <parameter type="integer" index="15.0" size="2.0" param="FILLING_HEIGHT" />
+      </frame>
   </frames>
   <paramset_defs></paramset_defs>
 </device>

--- a/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
+++ b/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
@@ -2,7 +2,7 @@
 <device version="2" rx_modes="CONFIG,WAKEUP,LAZY_CONFIG" cyclic_timeout="88700">
   <supported_types>
     <type name="HB-UNI-Sen-LEV-US" id="HB-UNI-Sen-LEV-US">
-	  <parameter index="9.0" size="1.0" cond_op="E" const_value="0x10"/>
+	  <parameter index="9.0" size="1.0" cond_op="GE" const_value="0x11"/>
       <parameter index="10.0" size="2.0" const_value="0xF9D2" />
     </type>
   </supported_types>
@@ -105,11 +105,18 @@
         </parameter>
         <parameter id="BATTERY_VOLTAGE" operations="read,event" control="NONE">
           <logical type="float" min="0.0" max="25.5" unit="V"/>
-           <physical type="integer" interface="command" value_id="BATTERY_VOLTAGE">
+          <physical type="integer" interface="command" value_id="BATTERY_VOLTAGE">
              <event frame="MEASURE_EVENT"/>
-           </physical>
-           <conversion type="float_integer_scale" factor="10"/>
+          </physical>
+          <conversion type="float_integer_scale" factor="10"/>
         </parameter>
+        <parameter id="FILLING_HEIGHT" operations="read,event" control="NONE">
+          <logical type="float" min="0.0" max="1000.0" unit="cm"/>
+          <physical type="integer" interface="command" value_id="FILLING_HEIGHT" no_init="true">
+            <event frame="MEASURE_EVENT"/>
+          </physical>
+          <conversion type="float_integer_scale" factor="1.0"/>
+        </parameter>				
       </paramset>  
       <paramset type="LINK" id="HB-UNI-Sen-LEV-US_link" />
     </channel>
@@ -119,7 +126,8 @@
          <parameter type="integer" index="9.0" size="1.0" param="FILLING_LEVEL" />
          <parameter type="integer" index="10.0" size="1.0" param="BATTERY_VOLTAGE"/>
          <parameter type="integer" index="11.0" size="4.0" param="FILLING_LITER"/>
-    </frame>
+		 <parameter type="integer" index="15.0" size="2.0" param="FILLING_HEIGHT" />
+	 </frame>
   </frames>
   <paramset_defs></paramset_defs>
 </device>

--- a/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
+++ b/src/addon/firmware/rftypes/hb-uni-sen-lev-us_ge_v1_1.xml
@@ -126,7 +126,7 @@
          <parameter type="integer" index="9.0" size="1.0" param="FILLING_LEVEL" />
          <parameter type="integer" index="10.0" size="1.0" param="BATTERY_VOLTAGE"/>
          <parameter type="integer" index="11.0" size="4.0" param="FILLING_LITER"/>
-		 <parameter type="integer" index="15.0" size="2.0" param="FILLING_HEIGHT" />
+	 <parameter type="integer" index="15.0" size="2.0" param="FILLING_HEIGHT" />
 	 </frame>
   </frames>
   <paramset_defs></paramset_defs>

--- a/src/addon/install_hb-uni-sen-lev-us
+++ b/src/addon/install_hb-uni-sen-lev-us
@@ -61,6 +61,11 @@ if [ -z "`cat $stringtable_deFile | grep \"CAPACITIVE_FILLING_LEVEL_SENSOR|FILLI
     echo -e $stringtable_deInsert >> $stringtable_deFile
 fi
 
+stringtable_deInsert="CAPACITIVE_FILLING_LEVEL_SENSOR|FILLING_HEIGHT\t\${stringTableCapacitiveFillingSensorFillingHeight}"
+if [ -z "`cat $stringtable_deFile | grep \"CAPACITIVE_FILLING_LEVEL_SENSOR|FILLING_HEIGHT"`" ]; then
+    echo -e $stringtable_deInsert >> $stringtable_deFile
+fi
+
 stringtable_deInsert="CAPACITIVE_FILLING_LEVEL_SENSOR|SENSOR_TYPE\t\${stringTableCapacitiveFillingSensorSensorType}"
 if [ -z "`cat $stringtable_deFile | grep \"CAPACITIVE_FILLING_LEVEL_SENSOR|SENSOR_TYPE"`" ]; then
     echo -e $stringtable_deInsert >> $stringtable_deFile
@@ -81,6 +86,11 @@ fi
 
 translate_deInsert="\n    \"stringTableCapacitiveFillingSensorFillingLiter\" : \"Liter\","
 if [ -z "`cat $translate_deFile | grep \"stringTableCapacitiveFillingSensorFillingLiter\"`" ]; then
+        sed -i "s/\($translate_deSearch\)/\1$translate_deInsert/g" $translate_deFile
+fi
+
+translate_deInsert="\n    \"stringTableCapacitiveFillingSensorFillingHeight\" : \"Aktuelle F%FCllh%F6he\","
+if [ -z "`cat $translate_deFile | grep \"stringTableCapacitiveFillingSensorFillingHeight\"`" ]; then
         sed -i "s/\($translate_deSearch\)/\1$translate_deInsert/g" $translate_deFile
 fi
 

--- a/src/addon/uninstall_hb-uni-sen-lev-us
+++ b/src/addon/uninstall_hb-uni-sen-lev-us
@@ -25,6 +25,8 @@ stringtable_deSearch="CAPACITIVE_FILLING_LEVEL_SENSOR|SENSOR_TYPE"
 sed -i "/\($stringtable_deSearch\)/d" $stringtable_deFile
 stringtable_deSearch="CAPACITIVE_FILLING_LEVEL_SENSOR|FILLING_LITER"
 sed -i "/\($stringtable_deSearch\)/d" $stringtable_deFile
+stringtable_deSearch="CAPACITIVE_FILLING_LEVEL_SENSOR|FILLING_HEIGHT"
+sed -i "/\($stringtable_deSearch\)/d" $stringtable_deFile
 
 translate_deFile="/www/webui/js/lang/de/translate.lang.stringtable.js"
 translate_deSearch="stringTableCapacitiveFillingSensorBatteryVoltage"
@@ -32,6 +34,10 @@ sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 translate_deSearch="stringTableCapacitiveFillingSensorDistanceOffset"
 sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 translate_deSearch="stringTableCapacitiveFillingSensorSensorType"
+sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
+# translate_deSearch="stringTableCapacitiveFillingSensorFillingLiter"
+# sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
+translate_deSearch="stringTableCapacitiveFillingSensorFillingHeight"
 sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 
 rm -f $FIRMWARE_FILE

--- a/src/addon/uninstall_hb-uni-sen-lev-us
+++ b/src/addon/uninstall_hb-uni-sen-lev-us
@@ -35,8 +35,8 @@ translate_deSearch="stringTableCapacitiveFillingSensorDistanceOffset"
 sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 translate_deSearch="stringTableCapacitiveFillingSensorSensorType"
 sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
-# translate_deSearch="stringTableCapacitiveFillingSensorFillingLiter"
-# sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
+translate_deSearch="stringTableCapacitiveFillingSensorFillingLiter"
+sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 translate_deSearch="stringTableCapacitiveFillingSensorFillingHeight"
 sed -i "/\(${translate_deSearch}\)/d" $translate_deFile
 


### PR DESCRIPTION
Firmware-Unterstützung V1.1 für die Darstellung der 'aktuellen Füllstandshöhe' in der WebUI (intern FILLING_HEIGHT).

!!! ANMERKUNG !!!
In der Datei 'uninstall_hb-uni-sen-lev-us' wurden die Zeilen 38 und 39 nur auskommentiert hinzugefügt - obwohl sie in der Ursprungsdatei nicht vorhanden sind, müssen sie m.E. ebenfalls aktiv sein, damit der FILLING_LITER Eintrag ebenfalls entfernt wird - bitte prüfen und Kommentierung entfernen !!! 