### PR TITLE
minor rc.d improvements

### DIFF
--- a/src/rc.d/jp-hb-devices-addon
+++ b/src/rc.d/jp-hb-devices-addon
@@ -55,7 +55,7 @@ check_rfd()
 case "$1" in
     ""|init|start)
       if [ ! -f ${ADDON_DIR}/installed ] || [ ! -f ${CK_FIRMWARE_FILE} ]; then       
-        echo "Starting complete installation within '$1'" > $GLOBAL_LOGFILE
+        echo "Starting complete installation within '$1'" | tee -a $GLOBAL_LOGFILE
         cp /dev/null $GLOBAL_ERRFILE
         cp /dev/null $PATCH_REVOKE_ERRFILE
 
@@ -143,7 +143,7 @@ case "$1" in
 
         ### Create Symlink to include own js file
         echo "(Re-)Creating symlinks for jp_webui_inc.js..." | tee -a $GLOBAL_LOGFILE
-        [[ ! -f /www/webui/js/extern/jp_webui_inc.js ]] && ln -s /usr/local/addons/jp-hb-devices-addon/js/jp_webui_inc.js /www/webui/js/extern/jp_webui_inc.js
+        [[ ! -f /www/webui/js/extern/jp_webui_inc.js ]] && ln -s /usr/local/addons/${ADDON_NAME}/js/jp_webui_inc.js /www/webui/js/extern/jp_webui_inc.js
 	    	    
         cd ${ADDON_DIR}
         echo "Running scripts..." | tee -a $GLOBAL_LOGFILE

--- a/src/rc.d/jp-hb-devices-addon
+++ b/src/rc.d/jp-hb-devices-addon
@@ -55,7 +55,7 @@ check_rfd()
 case "$1" in
     ""|init|start)
       if [ ! -f ${ADDON_DIR}/installed ] || [ ! -f ${CK_FIRMWARE_FILE} ]; then       
-        echo "Starting complete installation within '$1'" | tee -a $GLOBAL_LOGFILE
+        echo "Starting complete installation within '$1'" | tee $GLOBAL_LOGFILE
         cp /dev/null $GLOBAL_ERRFILE
         cp /dev/null $PATCH_REVOKE_ERRFILE
 

--- a/src/rc.d/jp-hb-devices-addon
+++ b/src/rc.d/jp-hb-devices-addon
@@ -143,7 +143,7 @@ case "$1" in
 
         ### Create Symlink to include own js file
         echo "(Re-)Creating symlinks for jp_webui_inc.js..." | tee -a $GLOBAL_LOGFILE
-        [[ ! -f /www/webui/js/extern/jp_webui_inc.js ]] && ln -s /usr/local/addons/${ADDON_NAME}/js/jp_webui_inc.js /www/webui/js/extern/jp_webui_inc.js
+        [[ ! -f /www/webui/js/extern/jp_webui_inc.js ]] && ln -s ${ADDON_DIR}/js/jp_webui_inc.js /www/webui/js/extern/jp_webui_inc.js
 	    	    
         cd ${ADDON_DIR}
         echo "Running scripts..." | tee -a $GLOBAL_LOGFILE


### PR DESCRIPTION
Moin Jerome,
zwei winzige rc.d updates:

1) du verwendest sehr oft das tee cmd und die logs zu verzweigen.
Beim Anfang von init|start wäre das auch angenehm, diese msg im logfile zu haben dachte ich.

2) das ist die einzige Stelle wo du nicht ${ADDON_NAME} verwendest sondern den fest codierten Namen.
Ist kein Problem bei dir solange du den Namen nicht änderst, nett wäre es die Variable zu nehmen, dann hätte ich eine Diff weniger beim Stripdown Projekt..
