### PR TITLE
Patch HB-UNI-Sen-CAP-MOIST(-T)

### DIFF
--- a/src/addon/firmware/rftypes/hb-uni-sen-cap-moist-t.xml
+++ b/src/addon/firmware/rftypes/hb-uni-sen-cap-moist-t.xml
@@ -8,7 +8,7 @@
   </supported_types>
   <paramset type="MASTER" id="hm_uni_sen_dev_master">
     <parameter id="LOW_BAT_LIMIT">
-      <logical type="float" min="1.9" max="6" default="2.2" unit="V" />
+      <logical type="float" min="1" max="6" default="2.2" unit="V" />
       <physical type="integer" interface="config" list="0" index="18" size="1" />
       <conversion type="float_integer_scale" factor="10" />
     </parameter>
@@ -70,7 +70,7 @@
      </paramset>
      <paramset type="VALUES" id="hb_cap_moist_values">
       <parameter id="TEMPERATURE" operations="read,event">
-       <logical type="float" min="-150.0" max="150.0" unit="°C" />
+       <logical type="float" min="-150.0" max="150.0" unit="Â°C" />
        <physical type="integer" interface="command" value_id="TEMPERATURE">
          <event frame="MEASURE_EVENT" />
        </physical>

--- a/src/addon/firmware/rftypes/hb-uni-sen-cap-moist.xml
+++ b/src/addon/firmware/rftypes/hb-uni-sen-cap-moist.xml
@@ -8,7 +8,7 @@
   </supported_types>
   <paramset type="MASTER" id="hm_uni_sen_dev_master">
     <parameter id="LOW_BAT_LIMIT">
-      <logical type="float" min="1.9" max="6" default="2.2" unit="V" />
+      <logical type="float" min="1" max="6" default="2.2" unit="V" />
       <physical type="integer" interface="config" list="0" index="18" size="1" />
       <conversion type="float_integer_scale" factor="10" />
     </parameter>


### PR DESCRIPTION
Set low battery value to 1 for support once battery cell at the step-up, e.g. with the @stan23 PCB.